### PR TITLE
accepts the Accept header value '*/*'

### DIFF
--- a/siden-core/src/main/java/ninja/siden/internal/MIMEPredicate.java
+++ b/siden-core/src/main/java/ninja/siden/internal/MIMEPredicate.java
@@ -59,6 +59,7 @@ public class MIMEPredicate implements Predicate {
 				.flatMap(List::stream)
 				.anyMatch(
 						v -> v.getValue().equals("*")
+								|| v.getValue().equals("*/*")
 								|| v.getValue().equals(contentType));
 	}
 }


### PR DESCRIPTION
Siden expects the requetst Accept header field values are `*` or a specific value(e.g. applcation/json) when you using `Routing#type(String type)` and then `MIMEPredicate#resolve(HttpServerExchange value)` resolves the header value.

The `*` value is valid, however, several http clients such as browsers, cURL send `*/*` instead of it in default.

```
curl localhost:8080/users -v
[...]
> GET /users HTTP/1.1
> User-Agent: curl/7.32.0
> Host: localhost:8080
> Accept: */*
> 
< HTTP/1.1 404 Not Found
[...]
```

```
curl -H "Accept: application/json" localhost:8080/users -v
[...]
> GET /users HTTP/1.1
> User-Agent: curl/7.32.0
> Host: localhost:8080
> Accept: application/json
> 
< HTTP/1.1 200 OK
[...]
{"name":"john"}%            
```

How about accepting the value `*/*` for easy to test ?
